### PR TITLE
Allow to set configuration by passing an object to `setConfig`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ NOTE 2: You may need to upgrade your version of mongodump (by upgrading mongo) d
       console.log('results: ', res);
     });
 
-By default, dumpstr will check for a file in your working directory called "conf.js", which should look something like this. 
+By default, dumpstr will check for a file in your working directory called "conf.js", which should look something like this.
 
     // This file is called conf.js
     module.exports = {
@@ -35,7 +35,7 @@ You can also update that path using setConfig.
 
     var md = require('dumpstr')
     , dump = md.dump;
-    
+
     md.setConfig("my_config_path/is_better.js");
 
 If you want to keep your configs in environment variables instead (Who could blame you?), go ahead and set these instead. That way you can leave out the config file entirely.
@@ -43,3 +43,17 @@ If you want to keep your configs in environment variables instead (Who could bla
     AWS_KEY
     AWS_SECRET
     AWS_BUCKET
+
+Or you can set your configuration by passing an object to `setConfig`:
+
+    var md = require('dumpstr');
+    , dump = md.dump;
+
+    md.setConfig({
+      aws: {
+        key: "MY_KEY_IS_HERE"
+      , secret: "THIS_IS_SECRET_HERE"
+      , bucket: "I_HAS_A_BUCKET"
+      , region: "REGION_HERE"
+      }
+    });

--- a/lib/conf.js
+++ b/lib/conf.js
@@ -1,12 +1,17 @@
 var confPath = process.cwd() + "/" + "conf.js"
   , confSet = false
+  , confObj
   , awsCreds
   , logLevel = 5
   , ll = require('loglevel');
 
-function setConfig (path) {
-  confSet = true;
-  confPath = path;
+function setConfig (pathOrConfig) {
+  if (typeof pathOrConfig === 'string') {
+    confSet = true;
+    confPath = pathOrConfig;
+  } else {
+    confObj = pathOrConfig;
+  }
 }
 
 function setLogLevel (n) {
@@ -16,8 +21,9 @@ function setLogLevel (n) {
 
 function aws () {
   if (confSet) { return require(confPath).aws; }
+  if (confObj) { return confObj.aws; }
   if (process.env.AWS_KEY && process.env.AWS_SECRET && process.env.AWS_BUCKET) {
-    return { 
+    return {
       key: process.env.AWS_KEY
     , secret: process.env.AWS_SECRET
     , bucket: process.env.AWS_BUCKET


### PR DESCRIPTION
Allow to configure dumpstr without forcing the user to create a file or set environment variables.